### PR TITLE
feat: add GitHub Actions CI/CD with DigitalOcean deploy and PR previews

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -1,0 +1,45 @@
+# delete-preview.yml
+#
+# Destroys the ephemeral preview Droplet when a pull request is closed
+# (merged or abandoned). Mirrors the digitalocean/app_action/delete pattern
+# from the DO App Platform docs, adapted for Droplets.
+#
+# Required GitHub Secrets:
+#   DIGITALOCEAN_ACCESS_TOKEN   - DO personal access token
+
+name: Delete PR Preview Environment
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  delete-preview:
+    name: Destroy preview Droplet for PR #${{ github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+
+    env:
+      PREVIEW_NAME: pr-${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Destroy preview Droplet
+        run: |
+          DROPLET_ID=$(doctl compute droplet list \
+            --format ID,Name --no-header \
+            | awk -v name="${PREVIEW_NAME}" '$2 == name {print $1}')
+
+          if [ -n "$DROPLET_ID" ]; then
+            echo "Destroying Droplet '${PREVIEW_NAME}' (ID: ${DROPLET_ID}) ..."
+            doctl compute droplet delete "$DROPLET_ID" --force
+            echo "Droplet destroyed."
+          else
+            echo "No Droplet found for '${PREVIEW_NAME}' — nothing to destroy."
+          fi

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
 jobs:
   delete-preview:
     name: Destroy preview Droplet for PR #${{ github.event.pull_request.number || inputs.pr_number }}

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -12,17 +12,22 @@ name: Delete PR Preview Environment
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose preview Droplet to destroy (e.g. 9)'
+        required: true
 
 permissions:
   contents: read
 
 jobs:
   delete-preview:
-    name: Destroy preview Droplet for PR #${{ github.event.pull_request.number }}
+    name: Destroy preview Droplet for PR #${{ github.event.pull_request.number || inputs.pr_number }}
     runs-on: ubuntu-latest
 
     env:
-      PREVIEW_NAME: pr-${{ github.event.pull_request.number }}
+      PREVIEW_NAME: pr-${{ github.event.pull_request.number || inputs.pr_number }}
 
     steps:
       - name: Install doctl

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -97,12 +97,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Deploy to Droplet via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ needs.bootstrap-droplet.outputs.ip }}
           username: ${{ secrets.DROPLET_USER || 'root' }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -94,15 +94,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Deploy to Droplet via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ needs.bootstrap-droplet.outputs.ip }}
           username: ${{ secrets.DROPLET_USER || 'root' }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,56 @@
+# deploy-app.yml
+#
+# Deploys the latest code to the production DigitalOcean Droplet on every push
+# to main or develop. Uses SSH to pull the repo and restart containers in-place.
+#
+# Required GitHub Secrets:
+#   DIGITALOCEAN_ACCESS_TOKEN   - DO personal access token (for doctl)
+#   DROPLET_HOST                - Production droplet IP or hostname
+#   DROPLET_USER                - SSH user on the droplet (e.g. root)
+#   DROPLET_SSH_KEY             - Private SSH key for droplet access
+#   DEPLOY_PATH                 - Absolute path on droplet (e.g. /srv/wordpress)
+
+name: Deploy App
+
+on:
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to production Droplet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Verify target Droplet is reachable
+        run: |
+          doctl compute droplet list --format Name,PublicIPv4,Status
+
+      - name: Deploy to Droplet via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USER }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script: |
+            set -e
+            cd "${{ secrets.DEPLOY_PATH }}"
+
+            echo "Pulling latest changes from ${{ github.ref_name }} ..."
+            git pull origin ${{ github.ref_name }}
+
+            echo "Restarting containers ..."
+            docker compose --profile ssl up -d --force-recreate --remove-orphans
+
+            echo "Deploy complete."

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -20,6 +20,7 @@ name: Deploy App
 on:
   push:
     branches: [main, develop]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -5,10 +5,15 @@
 #
 # Required GitHub Secrets:
 #   DIGITALOCEAN_ACCESS_TOKEN   - DO personal access token (for doctl)
-#   DROPLET_HOST                - Production droplet IP or hostname
-#   DROPLET_USER                - SSH user on the droplet (e.g. root)
+#   DO_SSH_KEY_FINGERPRINT      - SSH key fingerprint to inject into new Droplets
+#   DROPLET_HOST                - Production droplet IP (set after first run)
+#   DROPLET_USER                - SSH user on the droplet (default: root)
 #   DROPLET_SSH_KEY             - Private SSH key for droplet access
-#   DEPLOY_PATH                 - Absolute path on droplet (e.g. /srv/wordpress)
+#   DEPLOY_PATH                 - Absolute path on droplet (default: /srv/wordpress)
+#
+# First-run behaviour: if DROPLET_HOST is not set, bootstrap-droplet creates a
+# Droplet named "wordpress-production", prints the IP, then exits non-zero.
+# Add DROPLET_HOST=<ip> to GitHub Secrets and re-run to complete the deploy.
 
 name: Deploy App
 
@@ -19,10 +24,72 @@ on:
 permissions:
   contents: read
 
+env:
+  DROPLET_NAME: wordpress-production
+  DROPLET_REGION: nyc3
+  DROPLET_SIZE: s-1vcpu-2gb
+  DROPLET_IMAGE: docker-20-04
+
 jobs:
+  bootstrap-droplet:
+    name: Ensure production Droplet exists
+    runs-on: ubuntu-latest
+    outputs:
+      ip: ${{ steps.resolve.outputs.ip }}
+
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Create Droplet if it does not exist
+        id: resolve
+        run: |
+          # Use the secret directly if already set
+          if [ -n "${{ secrets.DROPLET_HOST }}" ]; then
+            echo "Using existing DROPLET_HOST secret."
+            echo "ip=${{ secrets.DROPLET_HOST }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          EXISTING_IP=$(doctl compute droplet list \
+            --format Name,PublicIPv4 --no-header \
+            | awk -v name="${DROPLET_NAME}" '$1 == name {print $2}')
+
+          if [ -n "$EXISTING_IP" ]; then
+            echo "Droplet '${DROPLET_NAME}' already exists at ${EXISTING_IP}."
+            echo "ip=${EXISTING_IP}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Creating Droplet '${DROPLET_NAME}' ..."
+          doctl compute droplet create "${DROPLET_NAME}" \
+            --size "${DROPLET_SIZE}" \
+            --image "${DROPLET_IMAGE}" \
+            --region "${DROPLET_REGION}" \
+            --ssh-keys "${{ secrets.DO_SSH_KEY_FINGERPRINT }}" \
+            --wait
+
+          sleep 30
+
+          NEW_IP=$(doctl compute droplet list \
+            --format Name,PublicIPv4 --no-header \
+            | awk -v name="${DROPLET_NAME}" '$1 == name {print $2}')
+
+          echo "ip=${NEW_IP}" >> "$GITHUB_OUTPUT"
+          echo ""
+          echo "================================================================"
+          echo "  Droplet created at: ${NEW_IP}"
+          echo "  ACTION REQUIRED: add this GitHub Secret, then re-run:"
+          echo "    DROPLET_HOST = ${NEW_IP}"
+          echo "================================================================"
+          exit 1
+
   deploy:
     name: Deploy to production Droplet
     runs-on: ubuntu-latest
+    needs: bootstrap-droplet
 
     steps:
       - name: Checkout repository
@@ -33,22 +100,27 @@ jobs:
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
-      - name: Verify target Droplet is reachable
-        run: |
-          doctl compute droplet list --format Name,PublicIPv4,Status
-
       - name: Deploy to Droplet via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.DROPLET_HOST }}
-          username: ${{ secrets.DROPLET_USER }}
+          host: ${{ needs.bootstrap-droplet.outputs.ip }}
+          username: ${{ secrets.DROPLET_USER || 'root' }}
           key: ${{ secrets.DROPLET_SSH_KEY }}
           script: |
             set -e
-            cd "${{ secrets.DEPLOY_PATH }}"
+            DEPLOY_PATH="${{ secrets.DEPLOY_PATH || '/srv/wordpress' }}"
 
+            if [ ! -d "${DEPLOY_PATH}/.git" ]; then
+              echo "First deploy — cloning repository ..."
+              git clone "https://github.com/${{ github.repository }}" "${DEPLOY_PATH}"
+            fi
+
+            cd "${DEPLOY_PATH}"
             echo "Pulling latest changes from ${{ github.ref_name }} ..."
             git pull origin ${{ github.ref_name }}
+
+            [ -f .env ] || cp env.example .env
+            mkdir -p src/{themes,plugins,uploads}
 
             echo "Restarting containers ..."
             docker compose --profile ssl up -d --force-recreate --remove-orphans

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-app-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DROPLET_NAME: wordpress-production
   DROPLET_REGION: nyc3

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -94,15 +94,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Deploy to Droplet via SSH
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ needs.bootstrap-droplet.outputs.ip }}
           username: ${{ secrets.DROPLET_USER || 'root' }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -112,7 +112,7 @@ jobs:
           echo "sha=${REGISTRY}/wordpress:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push WordPress image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: Dockerfile
@@ -122,7 +122,7 @@ jobs:
             ${{ steps.tags.outputs.sha }}
 
       - name: Deploy updated image to Droplet via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ needs.bootstrap-droplet.outputs.ip }}
           username: ${{ secrets.DROPLET_USER || 'root' }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -94,10 +94,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -112,7 +112,7 @@ jobs:
           echo "sha=${REGISTRY}/wordpress:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push WordPress image
-        uses: docker/build-push-action@v6.5.0
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: Dockerfile
@@ -122,7 +122,7 @@ jobs:
             ${{ steps.tags.outputs.sha }}
 
       - name: Deploy updated image to Droplet via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ needs.bootstrap-droplet.outputs.ip }}
           username: ${{ secrets.DROPLET_USER || 'root' }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -6,10 +6,15 @@
 # Required GitHub Secrets:
 #   DIGITALOCEAN_ACCESS_TOKEN   - DO personal access token (for doctl + registry)
 #   DO_REGISTRY_NAME            - DO registry name (e.g. myregistry, not the full URL)
-#   DROPLET_HOST                - Production droplet IP or hostname
-#   DROPLET_USER                - SSH user on the droplet (e.g. root)
+#   DO_SSH_KEY_FINGERPRINT      - SSH key fingerprint to inject into new Droplets
+#   DROPLET_HOST                - Production droplet IP (set after first run)
+#   DROPLET_USER                - SSH user on the droplet (default: root)
 #   DROPLET_SSH_KEY             - Private SSH key for droplet access
-#   DEPLOY_PATH                 - Absolute path on droplet (e.g. /srv/wordpress)
+#   DEPLOY_PATH                 - Absolute path on droplet (default: /srv/wordpress)
+#
+# First-run behaviour: if DROPLET_HOST is not set, bootstrap-droplet creates a
+# Droplet named "wordpress-production", prints the IP, then exits non-zero.
+# Add DROPLET_HOST=<ip> to GitHub Secrets and re-run to complete the deploy.
 
 name: Build, Push, and Deploy Image
 
@@ -20,10 +25,71 @@ on:
 permissions:
   contents: read
 
+env:
+  DROPLET_NAME: wordpress-production
+  DROPLET_REGION: nyc3
+  DROPLET_SIZE: s-1vcpu-2gb
+  DROPLET_IMAGE: docker-20-04
+
 jobs:
+  bootstrap-droplet:
+    name: Ensure production Droplet exists
+    runs-on: ubuntu-latest
+    outputs:
+      ip: ${{ steps.resolve.outputs.ip }}
+
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Create Droplet if it does not exist
+        id: resolve
+        run: |
+          if [ -n "${{ secrets.DROPLET_HOST }}" ]; then
+            echo "Using existing DROPLET_HOST secret."
+            echo "ip=${{ secrets.DROPLET_HOST }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          EXISTING_IP=$(doctl compute droplet list \
+            --format Name,PublicIPv4 --no-header \
+            | awk -v name="${DROPLET_NAME}" '$1 == name {print $2}')
+
+          if [ -n "$EXISTING_IP" ]; then
+            echo "Droplet '${DROPLET_NAME}' already exists at ${EXISTING_IP}."
+            echo "ip=${EXISTING_IP}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Creating Droplet '${DROPLET_NAME}' ..."
+          doctl compute droplet create "${DROPLET_NAME}" \
+            --size "${DROPLET_SIZE}" \
+            --image "${DROPLET_IMAGE}" \
+            --region "${DROPLET_REGION}" \
+            --ssh-keys "${{ secrets.DO_SSH_KEY_FINGERPRINT }}" \
+            --wait
+
+          sleep 30
+
+          NEW_IP=$(doctl compute droplet list \
+            --format Name,PublicIPv4 --no-header \
+            | awk -v name="${DROPLET_NAME}" '$1 == name {print $2}')
+
+          echo "ip=${NEW_IP}" >> "$GITHUB_OUTPUT"
+          echo ""
+          echo "================================================================"
+          echo "  Droplet created at: ${NEW_IP}"
+          echo "  ACTION REQUIRED: add this GitHub Secret, then re-run:"
+          echo "    DROPLET_HOST = ${NEW_IP}"
+          echo "================================================================"
+          exit 1
+
   build-push-deploy:
     name: Build image → push to DO registry → deploy
     runs-on: ubuntu-latest
+    needs: bootstrap-droplet
 
     steps:
       - name: Checkout repository
@@ -57,8 +123,8 @@ jobs:
       - name: Deploy updated image to Droplet via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.DROPLET_HOST }}
-          username: ${{ secrets.DROPLET_USER }}
+          host: ${{ needs.bootstrap-droplet.outputs.ip }}
+          username: ${{ secrets.DROPLET_USER || 'root' }}
           key: ${{ secrets.DROPLET_SSH_KEY }}
           script: |
             set -e

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,76 @@
+# deploy-image.yml
+#
+# Builds the WordPress Docker image, pushes it to the DigitalOcean Container
+# Registry, then deploys the new image to the production Droplet.
+#
+# Required GitHub Secrets:
+#   DIGITALOCEAN_ACCESS_TOKEN   - DO personal access token (for doctl + registry)
+#   DO_REGISTRY_NAME            - DO registry name (e.g. myregistry, not the full URL)
+#   DROPLET_HOST                - Production droplet IP or hostname
+#   DROPLET_USER                - SSH user on the droplet (e.g. root)
+#   DROPLET_SSH_KEY             - Private SSH key for droplet access
+#   DEPLOY_PATH                 - Absolute path on droplet (e.g. /srv/wordpress)
+
+name: Build, Push, and Deploy Image
+
+on:
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  build-push-deploy:
+    name: Build image → push to DO registry → deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 600
+
+      - name: Set image tags
+        id: tags
+        run: |
+          REGISTRY="registry.digitalocean.com/${{ secrets.DO_REGISTRY_NAME }}"
+          echo "latest=${REGISTRY}/wordpress:latest" >> "$GITHUB_OUTPUT"
+          echo "sha=${REGISTRY}/wordpress:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push WordPress image
+        uses: docker/build-push-action@v6.5.0
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.latest }}
+            ${{ steps.tags.outputs.sha }}
+
+      - name: Deploy updated image to Droplet via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USER }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script: |
+            set -e
+            cd "${{ secrets.DEPLOY_PATH }}"
+
+            echo "Authenticating with DO registry ..."
+            doctl registry login --expiry-seconds 600
+
+            echo "Pulling new image ..."
+            docker compose --profile ssl pull wordpress
+
+            echo "Restarting wordpress and webserver containers ..."
+            docker compose --profile ssl up -d --force-recreate --no-deps wordpress webserver
+
+            echo "Image deploy complete."

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -94,10 +94,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -112,7 +112,7 @@ jobs:
           echo "sha=${REGISTRY}/wordpress:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push WordPress image
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -122,7 +122,7 @@ jobs:
             ${{ steps.tags.outputs.sha }}
 
       - name: Deploy updated image to Droplet via SSH
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ needs.bootstrap-droplet.outputs.ip }}
           username: ${{ secrets.DROPLET_USER || 'root' }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -21,6 +21,7 @@ name: Build, Push, and Deploy Image
 on:
   push:
     branches: [main, develop]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-image-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DROPLET_NAME: wordpress-production
   DROPLET_REGION: nyc3

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,7 +55,7 @@ jobs:
             echo "Creating Droplet: ${PREVIEW_NAME} ..."
             doctl compute droplet create "${PREVIEW_NAME}" \
               --size s-1vcpu-1gb \
-              --image docker-24-04 \
+              --image ubuntu-24-04-x64 \
               --region nyc3 \
               --ssh-keys "${{ secrets.DO_SSH_KEY_FINGERPRINT }}" \
               --wait

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,6 +22,15 @@ on:
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to deploy preview for (e.g. 9)'
+        required: true
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: develop
 
 permissions:
   contents: read
@@ -29,11 +38,11 @@ permissions:
 
 jobs:
   deploy-preview:
-    name: Deploy preview for PR #${{ github.event.pull_request.number }}
+    name: Deploy preview for PR #${{ github.event.pull_request.number || inputs.pr_number }}
     runs-on: ubuntu-latest
 
     env:
-      PREVIEW_NAME: pr-${{ github.event.pull_request.number }}
+      PREVIEW_NAME: pr-${{ github.event.pull_request.number || inputs.pr_number }}
 
     steps:
       - name: Checkout repository
@@ -105,8 +114,8 @@ jobs:
 
             cd "${REPO_DIR}"
             git fetch origin
-            git checkout "${{ github.head_ref }}"
-            git reset --hard "origin/${{ github.head_ref }}"
+            git checkout "${{ github.head_ref || inputs.branch }}"
+            git reset --hard "origin/${{ github.head_ref || inputs.branch }}"
 
             # Write a minimal .env for preview (no SSL, IP as domain)
             cat > .env <<ENV
@@ -123,7 +132,7 @@ jobs:
             WORDPRESS_ADMIN_USER=${{ secrets.WORDPRESS_ADMIN_USER }}
             WORDPRESS_ADMIN_PASSWORD=${{ secrets.WORDPRESS_ADMIN_PASSWORD }}
             WORDPRESS_ADMIN_EMAIL=${{ secrets.WORDPRESS_ADMIN_EMAIL }}
-            WORDPRESS_BLOG_TITLE="PR Preview #${{ github.event.pull_request.number }}"
+            WORDPRESS_BLOG_TITLE="PR Preview #${{ github.event.pull_request.number || inputs.pr_number }}"
             ENV
 
             mkdir -p src/{themes,plugins,uploads}
@@ -149,7 +158,7 @@ jobs:
                 `| **URL** | ${{ steps.droplet.outputs.url }} |`,
                 `| **WP Admin** | ${{ steps.droplet.outputs.url }}/wp-login.php |`,
                 `| **Droplet** | \`${{ env.PREVIEW_NAME }}\` |`,
-                `| **Branch** | \`${{ github.head_ref }}\` |`,
+                `| **Branch** | \`${{ github.head_ref || inputs.branch }}\` |`,
                 '',
                 '_This preview Droplet will be destroyed automatically when the PR is closed._'
               ].join('\n')

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -122,14 +122,13 @@ jobs:
             WORDPRESS_ADMIN_USER=${{ secrets.WORDPRESS_ADMIN_USER }}
             WORDPRESS_ADMIN_PASSWORD=${{ secrets.WORDPRESS_ADMIN_PASSWORD }}
             WORDPRESS_ADMIN_EMAIL=${{ secrets.WORDPRESS_ADMIN_EMAIL }}
-            WORDPRESS_BLOG_TITLE=PR Preview #${{ github.event.pull_request.number }}
+            WORDPRESS_BLOG_TITLE="PR Preview #${{ github.event.pull_request.number }}"
             ENV
 
             mkdir -p src/{themes,plugins,uploads}
 
             # Mirrors local development: installs deps, brings up docker, waits for WP, runs wp_setup
-            WORDPRESS_BLOG_TITLE="PR Preview #${{ github.event.pull_request.number }}" \
-            ./wporchestrator first-time-bring-up --yes
+            TERM=dumb ./wporchestrator first-time-bring-up --yes
 
             echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -72,15 +72,28 @@ jobs:
           echo "ip=${IP}" >> "$GITHUB_OUTPUT"
           echo "url=http://${IP}" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for SSH to be ready
+        run: |
+          IP="${{ steps.droplet.outputs.ip }}"
+          echo "Waiting for SSH on ${IP}:22 ..."
+          for i in $(seq 1 30); do
+            if nc -z -w5 "${IP}" 22 2>/dev/null; then
+              echo "SSH is up after ${i} attempts."
+              exit 0
+            fi
+            echo "  attempt ${i}/30 — not ready yet, sleeping 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for SSH." && exit 1
+
       - name: Deploy preview to Droplet
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ steps.droplet.outputs.ip }}
           username: root
           key: ${{ secrets.DROPLET_SSH_KEY }}
-          # Retry a few times — the droplet may still be booting
-          retry_count: 5
-          retry_delay: 10
+          retry_count: 3
+          retry_delay: 5
           script: |
             set -e
             REPO_DIR="/srv/wordpress-preview"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -137,8 +137,9 @@ jobs:
 
             mkdir -p src/{themes,plugins,uploads}
 
-            # Fix ownership so the wordpress container (www-data) can write to the bind-mount
-            chown -R www-data:www-data src/
+            # Host www-data (uid 33) != container www-data (uid 82 on Alpine).
+            # For a preview environment, open permissions so both can write freely.
+            chmod -R 777 src/
 
             # Tear down any leftover containers from a previous run on this Droplet
             docker compose down --remove-orphans 2>/dev/null || true

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -137,8 +137,12 @@ jobs:
 
             mkdir -p src/{themes,plugins,uploads}
 
+            # Tear down any leftover containers from a previous run on this Droplet
+            docker compose down --remove-orphans 2>/dev/null || true
+
             # Mirrors local development: installs deps, brings up docker, waits for WP, runs wp_setup
-            TERM=dumb ./wporchestrator first-time-bring-up --yes
+            # --force removes .first_time_bring_up_complete so setup re-runs cleanly
+            TERM=dumb ./wporchestrator first-time-bring-up --force --yes
 
             echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -94,6 +94,7 @@ jobs:
           key: ${{ secrets.DROPLET_SSH_KEY }}
           retry_count: 3
           retry_delay: 5
+          command_timeout: 30m
           script: |
             set -e
             REPO_DIR="/srv/wordpress-preview"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,156 @@
+# deploy-preview.yml
+#
+# Spins up an ephemeral DigitalOcean Droplet for each pull request so the
+# changes can be reviewed at a live URL before merging. The Droplet is named
+# after the PR number (e.g. pr-42) and is destroyed by delete-preview.yml
+# when the PR is closed.
+#
+# Required GitHub Secrets:
+#   DIGITALOCEAN_ACCESS_TOKEN   - DO personal access token
+#   DO_SSH_KEY_FINGERPRINT      - Fingerprint of the SSH key to inject into new Droplets
+#   DROPLET_SSH_KEY             - Matching private key (used by appleboy/ssh-action)
+#   DATABASE_USER               - Copied from your local .env
+#   DATABASE_PASSWORD           - Copied from your local .env
+#   DATABASE_ROOT_PASSWORD      - Copied from your local .env
+#   WORDPRESS_ADMIN_USER        - Copied from your local .env
+#   WORDPRESS_ADMIN_PASSWORD    - Copied from your local .env
+#   WORDPRESS_ADMIN_EMAIL       - Copied from your local .env
+
+name: PR Preview Environment
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    name: Deploy preview for PR #${{ github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+
+    env:
+      PREVIEW_NAME: pr-${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Create preview Droplet if it does not exist
+        id: droplet
+        run: |
+          EXISTING_IP=$(doctl compute droplet list \
+            --format Name,PublicIPv4 --no-header \
+            | awk -v name="${PREVIEW_NAME}" '$1 == name {print $2}')
+
+          if [ -z "$EXISTING_IP" ]; then
+            echo "Creating Droplet: ${PREVIEW_NAME} ..."
+            doctl compute droplet create "${PREVIEW_NAME}" \
+              --size s-1vcpu-1gb \
+              --image docker-20-04 \
+              --region nyc3 \
+              --ssh-keys "${{ secrets.DO_SSH_KEY_FINGERPRINT }}" \
+              --wait
+            # Give cloud-init a moment to finish
+            sleep 30
+          else
+            echo "Droplet ${PREVIEW_NAME} already exists at ${EXISTING_IP}."
+          fi
+
+          IP=$(doctl compute droplet list \
+            --format Name,PublicIPv4 --no-header \
+            | awk -v name="${PREVIEW_NAME}" '$1 == name {print $2}')
+
+          echo "ip=${IP}" >> "$GITHUB_OUTPUT"
+          echo "url=http://${IP}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy preview to Droplet
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ steps.droplet.outputs.ip }}
+          username: root
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          # Retry a few times — the droplet may still be booting
+          retry_count: 5
+          retry_delay: 10
+          script: |
+            set -e
+            REPO_DIR="/srv/wordpress-preview"
+
+            if [ ! -d "${REPO_DIR}/.git" ]; then
+              git clone "https://github.com/${{ github.repository }}" "${REPO_DIR}"
+            fi
+
+            cd "${REPO_DIR}"
+            git fetch origin
+            git checkout "${{ github.head_ref }}"
+            git reset --hard "origin/${{ github.head_ref }}"
+
+            # Write a minimal .env for preview (no SSL, IP as domain)
+            cat > .env <<ENV
+            ENVIRONMENT=preview
+            ENABLE_SSL=false
+            ENABLE_WWW=false
+            DOMAIN_NAME=${{ steps.droplet.outputs.ip }}
+            CONTAINER_NAME=preview
+            DATABASE_NAME=wordpress
+            DATABASE_PORT=3306
+            DATABASE_USER=${{ secrets.DATABASE_USER }}
+            DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}
+            DATABASE_ROOT_PASSWORD=${{ secrets.DATABASE_ROOT_PASSWORD }}
+            WORDPRESS_ADMIN_USER=${{ secrets.WORDPRESS_ADMIN_USER }}
+            WORDPRESS_ADMIN_PASSWORD=${{ secrets.WORDPRESS_ADMIN_PASSWORD }}
+            WORDPRESS_ADMIN_EMAIL=${{ secrets.WORDPRESS_ADMIN_EMAIL }}
+            ENV
+
+            mkdir -p src/{themes,plugins,uploads}
+
+            docker compose up -d --force-recreate --remove-orphans
+
+            echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                '🚀 **Preview environment deployed!**',
+                '',
+                `| | |`,
+                `|---|---|`,
+                `| **URL** | ${{ steps.droplet.outputs.url }} |`,
+                `| **WP Admin** | ${{ steps.droplet.outputs.url }}/wp-login.php |`,
+                `| **Droplet** | \`${{ env.PREVIEW_NAME }}\` |`,
+                `| **Branch** | \`${{ github.head_ref }}\` |`,
+                '',
+                '_This preview Droplet will be destroyed automatically when the PR is closed._'
+              ].join('\n')
+            })
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                '❌ **Preview deployment failed.**',
+                '',
+                `[View workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`
+              ].join('\n')
+            })

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,7 +55,7 @@ jobs:
             echo "Creating Droplet: ${PREVIEW_NAME} ..."
             doctl compute droplet create "${PREVIEW_NAME}" \
               --size s-1vcpu-1gb \
-              --image docker-20-04 \
+              --image docker-24-04 \
               --region nyc3 \
               --ssh-keys "${{ secrets.DO_SSH_KEY_FINGERPRINT }}" \
               --wait

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -96,7 +96,7 @@ jobs:
           echo "Timed out waiting for SSH." && exit 1
 
       - name: Deploy preview to Droplet
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ steps.droplet.outputs.ip }}
           username: root
@@ -143,7 +143,7 @@ jobs:
             echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -166,7 +166,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,6 +36,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: deploy-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   deploy-preview:
     name: Deploy preview for PR #${{ github.event.pull_request.number || inputs.pr_number }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -128,6 +128,10 @@ jobs:
 
             docker compose up -d --force-recreate --remove-orphans
 
+            # Run WordPress setup non-interactively
+            WORDPRESS_BLOG_TITLE="PR Preview #${{ github.event.pull_request.number }}" \
+            bash admin/webserver/wp_setup.sh --env-file .env --yes
+
             echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
 
       - name: Comment preview URL on PR

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -96,7 +96,7 @@ jobs:
           echo "Timed out waiting for SSH." && exit 1
 
       - name: Deploy preview to Droplet
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ steps.droplet.outputs.ip }}
           username: root
@@ -143,7 +143,7 @@ jobs:
             echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             github.rest.issues.createComment({
@@ -166,7 +166,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -122,15 +122,14 @@ jobs:
             WORDPRESS_ADMIN_USER=${{ secrets.WORDPRESS_ADMIN_USER }}
             WORDPRESS_ADMIN_PASSWORD=${{ secrets.WORDPRESS_ADMIN_PASSWORD }}
             WORDPRESS_ADMIN_EMAIL=${{ secrets.WORDPRESS_ADMIN_EMAIL }}
+            WORDPRESS_BLOG_TITLE=PR Preview #${{ github.event.pull_request.number }}
             ENV
 
             mkdir -p src/{themes,plugins,uploads}
 
-            docker compose up -d --force-recreate --remove-orphans
-
-            # Run WordPress setup non-interactively
+            # Mirrors local development: installs deps, brings up docker, waits for WP, runs wp_setup
             WORDPRESS_BLOG_TITLE="PR Preview #${{ github.event.pull_request.number }}" \
-            bash admin/webserver/wp_setup.sh --env-file .env --yes
+            ./wporchestrator first-time-bring-up --yes
 
             echo "Preview deployed at ${{ steps.droplet.outputs.url }}"
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -96,7 +96,7 @@ jobs:
           echo "Timed out waiting for SSH." && exit 1
 
       - name: Deploy preview to Droplet
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ steps.droplet.outputs.ip }}
           username: root

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -137,6 +137,9 @@ jobs:
 
             mkdir -p src/{themes,plugins,uploads}
 
+            # Fix ownership so the wordpress container (www-data) can write to the bind-mount
+            chown -R www-data:www-data src/
+
             # Tear down any leftover containers from a previous run on this Droplet
             docker compose down --remove-orphans 2>/dev/null || true
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Docker-based local WordPress development environment with full CI/CD for Digit
 All dependencies are installed automatically by `./wporchestrator install_dependencies` on Ubuntu/Debian.
 
 Manual install if preferred:
+
 - [Docker](https://docs.docker.com/) + [Docker Compose plugin](https://docs.docker.com/compose/)
 - `yq` — `sudo apt-get install -y yq` (Ubuntu 24.04+) or `snap install yq`
 - `mysql-client` — `sudo apt-get install -y mysql-client`
@@ -45,16 +46,16 @@ WordPress will be available at `http://<DOMAIN_NAME>` (or `http://localhost` for
 
 ## wporchestrator Commands
 
-| Command | Description |
-|---|---|
-| `first-time-bring-up [--yes]` | Install deps, start containers, run WordPress setup |
-| `install_dependencies` | Install system packages (Docker, mysql-client, yq, etc.) |
-| `wp-setup [--yes]` | Run WordPress configuration (title, admin user, plugins, permalinks) |
-| `restore-from-backup <file>` | Restore an UpdraftPlus `.db.gz` backup, fix URLs, fetch fonts |
-| `fix-urls` | Reset `siteurl`/`home` to localhost after a production DB restore |
-| `enable-ssl-after-first-time-bring-up` | Obtain Let's Encrypt certs and switch site to HTTPS |
-| `logs` | Tail logs from all Docker Compose services |
-| `nuke` | Destroy all containers and volumes (**destructive**) |
+| Command                                | Description                                                          |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| `first-time-bring-up [--yes]`          | Install deps, start containers, run WordPress setup                  |
+| `install_dependencies`                 | Install system packages (Docker, mysql-client, yq, etc.)             |
+| `wp-setup [--yes]`                     | Run WordPress configuration (title, admin user, plugins, permalinks) |
+| `restore-from-backup <file>`           | Restore an UpdraftPlus `.db.gz` backup, fix URLs, fetch fonts        |
+| `fix-urls`                             | Reset `siteurl`/`home` to localhost after a production DB restore    |
+| `enable-ssl-after-first-time-bring-up` | Obtain Let's Encrypt certs and switch site to HTTPS                  |
+| `logs`                                 | Tail logs from all Docker Compose services                           |
+| `nuke`                                 | Destroy all containers and volumes (**destructive**)                 |
 
 `--yes` / `--non-interactive` — skips all interactive prompts; requires credentials set in `.env`.
 
@@ -67,6 +68,7 @@ WordPress will be available at `http://<DOMAIN_NAME>` (or `http://localhost` for
 ```
 
 This will:
+
 1. Copy the backup into the database container
 2. Import it (directly via `mysql`, bypassing WP-CLI TLS issues with MySQL 8)
 3. Auto-detect and write the table prefix to `.env`
@@ -93,6 +95,7 @@ Requires `PRODUCTION_DOMAIN` set in `.env`.
 Four workflows are included in `.github/workflows/`:
 
 ### `deploy-preview.yml` — PR Preview Environments
+
 - Triggers on pull requests to `main` or `develop`
 - Creates an ephemeral DigitalOcean Droplet named `pr-<N>` (Ubuntu 24.04, Docker pre-installed)
 - Clones the branch, writes a minimal `.env`, runs `./wporchestrator first-time-bring-up --yes`
@@ -100,33 +103,36 @@ Four workflows are included in `.github/workflows/`:
 - Destroys the Droplet when the PR is closed (`delete-preview.yml`)
 
 ### `deploy-app.yml` — Deploy to Production Droplet
+
 - Triggers on push to `main` or `develop`
 - SSHes into `DROPLET_HOST`, pulls latest, runs `docker compose up -d`
 
 ### `deploy-image.yml` — Build & Push Docker Image
+
 - Builds a custom WordPress image, pushes to DigitalOcean Container Registry
 - SSHes into Droplet, pulls new image, restarts services
 
 ### `delete-preview.yml` — Destroy PR Preview
+
 - Triggers when a PR is closed
 - Finds and destroys the `pr-<N>` Droplet via `doctl`
 
 ### Required GitHub Secrets
 
-| Secret | Description |
-|---|---|
-| `DIGITALOCEAN_ACCESS_TOKEN` | DO personal access token |
-| `DO_SSH_KEY_FINGERPRINT` | Fingerprint of SSH key registered in DO account |
-| `DROPLET_SSH_KEY` | Private key matching `DO_SSH_KEY_FINGERPRINT` |
-| `DROPLET_USER` | SSH user on the Droplet (default: `root`) |
-| `DEPLOY_PATH` | Path on Droplet to clone repo (default: `/srv/wordpress`) |
-| `DO_REGISTRY_NAME` | DO Container Registry name (for `deploy-image.yml`) |
-| `DATABASE_USER` | |
-| `DATABASE_PASSWORD` | |
-| `DATABASE_ROOT_PASSWORD` | |
-| `WORDPRESS_ADMIN_USER` | |
-| `WORDPRESS_ADMIN_PASSWORD` | |
-| `WORDPRESS_ADMIN_EMAIL` | |
+| Secret                      | Description                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `DIGITALOCEAN_ACCESS_TOKEN` | DO personal access token                                  |
+| `DO_SSH_KEY_FINGERPRINT`    | Fingerprint of SSH key registered in DO account           |
+| `DROPLET_SSH_KEY`           | Private key matching `DO_SSH_KEY_FINGERPRINT`             |
+| `DROPLET_USER`              | SSH user on the Droplet (default: `root`)                 |
+| `DEPLOY_PATH`               | Path on Droplet to clone repo (default: `/srv/wordpress`) |
+| `DO_REGISTRY_NAME`          | DO Container Registry name (for `deploy-image.yml`)       |
+| `DATABASE_USER`             |                                                           |
+| `DATABASE_PASSWORD`         |                                                           |
+| `DATABASE_ROOT_PASSWORD`    |                                                           |
+| `WORDPRESS_ADMIN_USER`      |                                                           |
+| `WORDPRESS_ADMIN_PASSWORD`  |                                                           |
+| `WORDPRESS_ADMIN_EMAIL`     |                                                           |
 
 `DROPLET_HOST` is **not** required upfront — the bootstrap job creates a Droplet on first run and prints the IP.
 

--- a/README.md
+++ b/README.md
@@ -1,72 +1,157 @@
 # local-wordpress-development
 
-Another Docker Configuration for Local WordPress development
+A Docker-based local WordPress development environment with full CI/CD for DigitalOcean deployments.
 
-## Installation - In progress
+## Features
 
-#### Prerequisites
+- **One-command setup** via `wporchestrator` — installs dependencies, brings up containers, configures WordPress
+- **Production DB restore** — import UpdraftPlus backups, auto-detect table prefix, rewrite URLs, fetch custom fonts
+- **PR Preview Environments** — ephemeral DigitalOcean Droplets spun up per pull request, destroyed on PR close
+- **SSL support** via Let's Encrypt (certbot) for production deployments
+- **Non-interactive / CI mode** — `--yes` flag skips all prompts for automated runs
 
--   Install Git
-    -   if Linux and debian/ubuntu
-        -   `sudo apt install git`
--   Install [Docker](https://docs.docker.com/)
--   Install [Docker Compose](https://docs.docker.com/compose/)
--   Install [mkcert](https://github.com/FiloSottile/mkcert)
-    -   If Ubuntu/Debian,
-        -   `sudo apt install golang` is needed to build to install mkcert
--   Install [yq](https://github.com/mikefarah/yq)
-    -   If Ubuntu/Debian,
-        -   sudo apt-get update && sudo apt-get install -y yq
+---
 
-#### Initialization
+## Prerequisites
 
--   Clone [this repository](https://github.com/michaelolsonengineer/local-wordpress-development)
--   Copy env.example to .env on host environment at root of workspace of desired server
--   Edit newly created .env with desired secret credentials
--   NOTE: if local development only, then create self-signed certificates
+All dependencies are installed automatically by `./wporchestrator install_dependencies` on Ubuntu/Debian.
 
-#### Build/Run
+Manual install if preferred:
+- [Docker](https://docs.docker.com/) + [Docker Compose plugin](https://docs.docker.com/compose/)
+- `yq` — `sudo apt-get install -y yq` (Ubuntu 24.04+) or `snap install yq`
+- `mysql-client` — `sudo apt-get install -y mysql-client`
+- `git`, `curl`, `wget`, `jq` — `sudo apt-get install -y git curl wget jq`
 
--   if first time
-    -   `docker compose up --build`
--   else
-    -   `docker compose up`
+---
 
-## Troubleshooting and Helpful Tips
+## Quick Start (Local Development)
 
--   Do not edit docker configurations while docker is running.
+```bash
+# 1. Clone the repo
+git clone https://github.com/michaelolsonengineer/local-wordpress-development
+cd local-wordpress-development
 
-    -   Bring system down before editing. It can cause docker compose to have difficulty finding containers for example.
+# 2. Configure environment
+cp env.example .env
+# Edit .env with your credentials (DOMAIN_NAME, DATABASE_*, WORDPRESS_ADMIN_*, etc.)
 
--   Make sure to stop any local running databases that might conflict with databases defined in the docker compose files.
+# 3. First-time bring-up: installs deps, starts containers, runs WordPress setup
+./wporchestrator first-time-bring-up
+```
 
-    -   i.e. `sudo systemctl stop mysql`
+WordPress will be available at `http://<DOMAIN_NAME>` (or `http://localhost` for local dev).
 
-#### Know some basic docker commands
+---
 
--   `docker container ls`
-    -   list containers
--   `docker volume ls`
-    -   list volumes
--   `docker log <CONTAINER_NAME>`
-    -   show system logs till now of CONTAINER_NAME
--   `docker ps -a`
-    -   show any existing running containers
--   `docker volume prune`
-    -   remove any dangling volumes if existing
--   `docker rm $(docker ps -a -f status=exited -q)`
-    -   remove any exited containers if existing
--   If you are needing to really nuke, know how to do that with docker and/or make the scripts
-    -   `docker volume rm $DIRECTORY_NAME_wordpress $DIRECTORY_NAME_dbdata`
-    -   i.e `docker volume rm wp_wordpress wp_dbdata`
+## wporchestrator Commands
+
+| Command | Description |
+|---|---|
+| `first-time-bring-up [--yes]` | Install deps, start containers, run WordPress setup |
+| `install_dependencies` | Install system packages (Docker, mysql-client, yq, etc.) |
+| `wp-setup [--yes]` | Run WordPress configuration (title, admin user, plugins, permalinks) |
+| `restore-from-backup <file>` | Restore an UpdraftPlus `.db.gz` backup, fix URLs, fetch fonts |
+| `fix-urls` | Reset `siteurl`/`home` to localhost after a production DB restore |
+| `enable-ssl-after-first-time-bring-up` | Obtain Let's Encrypt certs and switch site to HTTPS |
+| `logs` | Tail logs from all Docker Compose services |
+| `nuke` | Destroy all containers and volumes (**destructive**) |
+
+`--yes` / `--non-interactive` — skips all interactive prompts; requires credentials set in `.env`.
+
+---
+
+## Production DB Restore
+
+```bash
+./wporchestrator restore-from-backup '/path/to/backup_2026-04-26-db.gz'
+```
+
+This will:
+1. Copy the backup into the database container
+2. Import it (directly via `mysql`, bypassing WP-CLI TLS issues with MySQL 8)
+3. Auto-detect and write the table prefix to `.env`
+4. Rewrite production domain URLs to `http://localhost` in `options` and `postmeta`
+5. Download any custom fonts referenced in `postmeta`
+6. Create/update the local admin user from `.env` credentials
+7. Report the AIOS custom login slug if All-In-One Security is active
+
+---
+
+## Enabling SSL (Production)
+
+```bash
+# After first-time-bring-up with a real domain pointed at the server:
+./wporchestrator enable-ssl-after-first-time-bring-up
+```
+
+Requires `PRODUCTION_DOMAIN` set in `.env`.
+
+---
+
+## CI/CD — GitHub Actions
+
+Four workflows are included in `.github/workflows/`:
+
+### `deploy-preview.yml` — PR Preview Environments
+- Triggers on pull requests to `main` or `develop`
+- Creates an ephemeral DigitalOcean Droplet named `pr-<N>` (Ubuntu 24.04, Docker pre-installed)
+- Clones the branch, writes a minimal `.env`, runs `./wporchestrator first-time-bring-up --yes`
+- Comments the live preview URL on the PR
+- Destroys the Droplet when the PR is closed (`delete-preview.yml`)
+
+### `deploy-app.yml` — Deploy to Production Droplet
+- Triggers on push to `main` or `develop`
+- SSHes into `DROPLET_HOST`, pulls latest, runs `docker compose up -d`
+
+### `deploy-image.yml` — Build & Push Docker Image
+- Builds a custom WordPress image, pushes to DigitalOcean Container Registry
+- SSHes into Droplet, pulls new image, restarts services
+
+### `delete-preview.yml` — Destroy PR Preview
+- Triggers when a PR is closed
+- Finds and destroys the `pr-<N>` Droplet via `doctl`
+
+### Required GitHub Secrets
+
+| Secret | Description |
+|---|---|
+| `DIGITALOCEAN_ACCESS_TOKEN` | DO personal access token |
+| `DO_SSH_KEY_FINGERPRINT` | Fingerprint of SSH key registered in DO account |
+| `DROPLET_SSH_KEY` | Private key matching `DO_SSH_KEY_FINGERPRINT` |
+| `DROPLET_USER` | SSH user on the Droplet (default: `root`) |
+| `DEPLOY_PATH` | Path on Droplet to clone repo (default: `/srv/wordpress`) |
+| `DO_REGISTRY_NAME` | DO Container Registry name (for `deploy-image.yml`) |
+| `DATABASE_USER` | |
+| `DATABASE_PASSWORD` | |
+| `DATABASE_ROOT_PASSWORD` | |
+| `WORDPRESS_ADMIN_USER` | |
+| `WORDPRESS_ADMIN_PASSWORD` | |
+| `WORDPRESS_ADMIN_EMAIL` | |
+
+`DROPLET_HOST` is **not** required upfront — the bootstrap job creates a Droplet on first run and prints the IP.
+
+---
+
+## Troubleshooting
+
+- **Stop local MySQL** before bringing up containers — it conflicts with the database container:
+  `sudo systemctl stop mysql`
+
+- **Do not edit docker-compose.yml while containers are running** — bring the stack down first.
+
+- **Useful Docker commands:**
+  ```bash
+  docker compose ps                        # show running services
+  docker compose logs <service>            # view logs for a service
+  docker compose down                      # stop and remove containers
+  docker volume prune                      # remove unused volumes
+  ```
+
+---
 
 ## Acknowledgments
 
--   Repo originally started from - [Wazoo's Github Repo of Local Wordpress development](https://github.com/wazooinc/local-wordpress-development)
-
-    -   Going off of material from [Docker Setup for Local WordPress Development](https://www.youtube.com/watch?v=GG2k-La5t3or) for step-by-step guide
-    -   And [Adding SSL to Wordpress](https://www.youtube.com/watch?v=HH4s3x1PiA4) (aka pt2) which will need a [self-signed certificates tool](https://github.com/FiloSottile/mkcert) local development
-
--   And mixing with [How To Install WordPress With Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-install-wordpress-with-docker-compose) another step-by-step for refresher
-
--   and my own docker experience since it had been some 3+ years since I have worked with docker and web stuff
+- Originally derived from [Wazoo's local-wordpress-development](https://github.com/wazooinc/local-wordpress-development)
+- [How To Install WordPress With Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-install-wordpress-with-docker-compose) — DigitalOcean tutorial
+- [Adding SSL to WordPress](https://www.youtube.com/watch?v=HH4s3x1PiA4) — Let's Encrypt + nginx setup
+- [mkcert](https://github.com/FiloSottile/mkcert) — self-signed certs for local HTTPS

--- a/admin/webserver/wp_setup.sh
+++ b/admin/webserver/wp_setup.sh
@@ -45,6 +45,10 @@ __script_help() { # Required
 # Inputs:
     --env-file:
         the configuration file for reading default staging environment configuration information
+    --yes | --non-interactive:
+        skip all interactive prompts; requires WORDPRESS_ADMIN_EMAIL, WORDPRESS_ADMIN_USER,
+        and WORDPRESS_ADMIN_PASSWORD to already be set in the .env file or environment.
+        WORDPRESS_BLOG_TITLE may also be set; defaults to "WordPress" if absent.
 
 EOM
 
@@ -66,6 +70,7 @@ __script_parse_opts() { # Optional
   declare -xg WORDPRESS_ADMIN_USER
   declare -xg WORDPRESS_ADMIN_PASSWORD
   declare -xg wordpress_blog_title
+  declare -xg NON_INTERACTIVE=false
   # shellcheck disable=SC2155
   declare -xg temp_dir=$(mktemp -d)
 
@@ -77,6 +82,9 @@ __script_parse_opts() { # Optional
     --env-file)
       shift
       environment_file="${1}"
+      ;;
+    --yes | --non-interactive)
+      NON_INTERACTIVE=true
       ;;
     -h | --help | help)
       __script_help
@@ -176,24 +184,35 @@ __script_init() { # Optional
     done
   }
 
-  prompt_user_for_wordpress_admin_account
-
-  while true; do
-    echo -en "\n"
-    info "Note: admin and title details will be prompted for again if dismissed. "
-    read -rp "Is the information correct? [Y/n] " confirmation
-    confirmation=${confirmation,,}
-    if [[ "${confirmation}" =~ ^(yes|y)$ ]] || [ -z "${confirmation}" ]; then
-      break
-    else
-      unset WORDPRESS_ADMIN_EMAIL
-      unset WORDPRESS_ADMIN_USER
-      unset WORDPRESS_ADMIN_PASSWORD
-      unset wordpress_blog_title
-
-      prompt_user_for_wordpress_admin_account
+  if [ "${NON_INTERACTIVE}" = "true" ]; then
+    # In non-interactive mode, values must already be set (from .env or environment).
+    # Pull blog title from env if not set.
+    wordpress_blog_title="${wordpress_blog_title:-${WORDPRESS_BLOG_TITLE:-WordPress}}"
+    if [ -z "${WORDPRESS_ADMIN_EMAIL-}" ] || [ -z "${WORDPRESS_ADMIN_USER-}" ] || [ -z "${WORDPRESS_ADMIN_PASSWORD-}" ]; then
+      error "--yes/--non-interactive requires WORDPRESS_ADMIN_EMAIL, WORDPRESS_ADMIN_USER, and WORDPRESS_ADMIN_PASSWORD to be set in the environment or .env file."
+      exit 1
     fi
-  done
+    info "Non-interactive mode: using credentials from environment."
+  else
+    prompt_user_for_wordpress_admin_account
+
+    while true; do
+      echo -en "\n"
+      info "Note: admin and title details will be prompted for again if dismissed. "
+      read -rp "Is the information correct? [Y/n] " confirmation
+      confirmation=${confirmation,,}
+      if [[ "${confirmation}" =~ ^(yes|y)$ ]] || [ -z "${confirmation}" ]; then
+        break
+      else
+        unset WORDPRESS_ADMIN_EMAIL
+        unset WORDPRESS_ADMIN_USER
+        unset WORDPRESS_ADMIN_PASSWORD
+        unset wordpress_blog_title
+
+        prompt_user_for_wordpress_admin_account
+      fi
+    done
+  fi
 
   info "Ready to add admin user ..."
 }

--- a/admin/webserver/wp_setup.sh
+++ b/admin/webserver/wp_setup.sh
@@ -277,11 +277,15 @@ __script_exec() { # Required
   # ${wp_cli} user create \
   #   "${WORDPRESS_ADMIN_USER}" "${WORDPRESS_ADMIN_EMAIL}" --role=administrator --user_pass="${WORDPRESS_ADMIN_PASSWORD}"
 
-  info "Updating WordPress core to latest version ..."
-  run ${wp_cli} core update --allow-root --path="${WEBSERVER_ROOT}" ||
-    error "failed to update WordPress core through wp-cli ..."
-  run ${wp_cli} core update-db --allow-root --path="${WEBSERVER_ROOT}" ||
-    error "failed to run WordPress DB migrations after core update ..."
+  if [ "${NON_INTERACTIVE}" = "true" ]; then
+    info "Skipping wp core update in non-interactive/CI mode (image ships recent version)."
+  else
+    info "Updating WordPress core to latest version ..."
+    run ${wp_cli} core update --allow-root --path="${WEBSERVER_ROOT}" ||
+      error "failed to update WordPress core through wp-cli ..."
+    run ${wp_cli} core update-db --allow-root --path="${WEBSERVER_ROOT}" ||
+      error "failed to run WordPress DB migrations after core update ..."
+  fi
 
   # Remove default posts, widgets, comments etc.
   info "Removing default posts, widgets, comments etc ..."

--- a/tools/common/constants.sh
+++ b/tools/common/constants.sh
@@ -24,15 +24,15 @@ declare -xg WS_ENV_FILE="${WORKSPACE}/.env"
 # and https://tldp.org/HOWTO/Bash-Prompt-HOWTO/x361.html
 # for more info on tput
 # and https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
-declare -xg FG_BLACK="$(tput setaf 0)"
-declare -xg FG_RED="$(tput setaf 1)"
-declare -xg FG_GREEN="$(tput setaf 2)"
-declare -xg FG_YELLOW="$(tput setaf 3)"
-declare -xg FG_BLUE="$(tput setaf 4)"
-declare -xg FG_MAGENTA="$(tput setaf 5)"
-declare -xg FG_CYAN="$(tput setaf 6)"
-declare -xg FG_WHITE="$(tput setaf 7)"
-declare -xg STYLE_RESET="$(tput sgr0)"
+declare -xg FG_BLACK="$(tput setaf 0 2>/dev/null || true)"
+declare -xg FG_RED="$(tput setaf 1 2>/dev/null || true)"
+declare -xg FG_GREEN="$(tput setaf 2 2>/dev/null || true)"
+declare -xg FG_YELLOW="$(tput setaf 3 2>/dev/null || true)"
+declare -xg FG_BLUE="$(tput setaf 4 2>/dev/null || true)"
+declare -xg FG_MAGENTA="$(tput setaf 5 2>/dev/null || true)"
+declare -xg FG_CYAN="$(tput setaf 6 2>/dev/null || true)"
+declare -xg FG_WHITE="$(tput setaf 7 2>/dev/null || true)"
+declare -xg STYLE_RESET="$(tput sgr0 2>/dev/null || true)"
 
 # source https://stackoverflow.com/a/28938235
 declare -xg STYLE_RESET='\033[0;0m' # Text Reset

--- a/tools/common/dependencies.sh
+++ b/tools/common/dependencies.sh
@@ -55,6 +55,12 @@ install_basic_packages() {
     install_basic_group=true
   fi
 
+  local install_acl=""
+  if ! is_installed "setfacl"; then
+    install_acl="acl"
+    install_basic_group=true
+  fi
+
   if [ "${install_basic_group}" = true ]; then
     log INFO "Installing necessary basic packages"
     # shellcheck disable=SC2086
@@ -64,7 +70,8 @@ install_basic_packages() {
       ${install_git} \
       ${install_pip3} \
       ${install_jq} \
-      ${install_yq}
+      ${install_yq} \
+      ${install_acl}
   fi
 }
 

--- a/wporchestrator
+++ b/wporchestrator
@@ -317,17 +317,28 @@ first_time_bring_up() {
   # Host www-data (uid 33) != container www-data (uid 82 on Alpine fpm), so chown
   # alone does not help. Strategy depends on environment:
   #
-  #   preview / production (CI, root-owned Droplet):
-  #     chmod 777 — simple, no security concern on an ephemeral/isolated host.
+  #   production:
+  #     chown 82:82 + chmod 755/644 — tight permissions, only the container writes.
+  #
+  #   preview (ephemeral CI Droplet):
+  #     chmod 777 — simple, no security concern on an isolated/short-lived host.
   #
   #   local (developer workstation):
-  #     Use POSIX ACLs to grant uid 82 (container www-data) rw access while
-  #     keeping the developer as owner so no sudo is needed for edits.
-  #     Falls back to chown developer:www-data + 775 if setfacl is unavailable.
+  #     POSIX ACLs grant uid 82 (container www-data) rw access while keeping the
+  #     developer as owner so no sudo is needed for edits.
+  #     Falls back to chown developer:group + chmod 775 if setfacl is unavailable.
   #
   local _env="${ENVIRONMENT:-local}"
-  if [ "${_env}" = "preview" ] || [ "${_env}" = "production" ]; then
-    info "Preview/production environment — setting src/ to 777 ..."
+  if [ "${_env}" = "production" ]; then
+    # Production: own by container's www-data (uid 82 on Alpine fpm).
+    # Directories 755, files 644 — only the container can write.
+    info "Production environment — chown 82:82 + chmod 755/644 on src/ ..."
+    sudo chown -R 82:82 "${WORKSPACE}/src" || true
+    sudo find "${WORKSPACE}/src" -type d -exec chmod 755 {} + || true
+    sudo find "${WORKSPACE}/src" -type f -exec chmod 644 {} + || true
+  elif [ "${_env}" = "preview" ]; then
+    # Preview: ephemeral/isolated host, chmod 777 is fine and avoids uid mismatch complexity.
+    info "Preview environment — setting src/ to 777 ..."
     sudo chmod -R 777 "${WORKSPACE}/src" || true
   else
     info "Local environment — applying ACL for container uid 82 on src/ ..."

--- a/wporchestrator
+++ b/wporchestrator
@@ -312,6 +312,10 @@ first_time_bring_up() {
   # Check if wordpress files were created
   [ -e "${WORKSPACE}/src" ] ||
     error "WordPress src bind-mount not found — did the volume fail to populate?"
+
+  # Fix ownership so the wordpress container (www-data) can write to the bind-mount
+  info "Setting ownership of src/ to www-data ..."
+  sudo chown -R www-data:www-data "${WORKSPACE}/src" || true
   info "All containers up. Run './wporchestrator logs' to inspect individual container output."
 
   info "Running WordPress setup ..."

--- a/wporchestrator
+++ b/wporchestrator
@@ -313,9 +313,12 @@ first_time_bring_up() {
   [ -e "${WORKSPACE}/src" ] ||
     error "WordPress src bind-mount not found — did the volume fail to populate?"
 
-  # Fix ownership so the wordpress container (www-data) can write to the bind-mount
-  info "Setting ownership of src/ to www-data ..."
-  sudo chown -R www-data:www-data "${WORKSPACE}/src" || true
+  # Fix ownership so both the wordpress container (www-data) and the local developer can write.
+  # www-data owns the files; the developer's group gets group-write via setgid + g+w.
+  info "Setting ownership of src/ to www-data:$(id -gn) with group-write ..."
+  sudo chown -R www-data:"$(id -gn)" "${WORKSPACE}/src" || true
+  sudo chmod -R g+w "${WORKSPACE}/src" || true
+  sudo find "${WORKSPACE}/src" -type d -exec chmod g+s {} + || true
   info "All containers up. Run './wporchestrator logs' to inspect individual container output."
 
   info "Running WordPress setup ..."

--- a/wporchestrator
+++ b/wporchestrator
@@ -70,6 +70,9 @@ __script_help() { # Required
         nuke:
             nuke. Don't use this unless you are sure
     args:
+        --yes | --non-interactive:
+            Skip all interactive prompts in wp_setup. Requires WORDPRESS_ADMIN_EMAIL,
+            WORDPRESS_ADMIN_USER, and WORDPRESS_ADMIN_PASSWORD in the .env file.
 
 # Side Effects
     None
@@ -90,12 +93,16 @@ __script_parse_opts() { # Optional
   declare -xg _do_first_time_bring_up_flag="false"
   declare -xg _do_enable_ssl_after_first_time_bring_up_flag="false"
   declare -xg force="false"
+  declare -xg yes="false"
 
   # Parse options
   while (($#)); do
     case "${1}" in
     --force)
       force="true"
+      ;;
+    --yes | --non-interactive)
+      yes="true"
       ;;
     install_dependencies)
       info "Running install_dependencies ..."
@@ -116,7 +123,9 @@ __script_parse_opts() { # Optional
       ;;
     wp-setup)
       info "Running wp-setup ..."
-      bash "${WORKSPACE}/admin/webserver/wp_setup.sh" --env-file "${WORKSPACE}/.env"
+      local _wp_setup_yes_flag=""
+      [ "${yes}" = "true" ] && _wp_setup_yes_flag="--yes"
+      bash "${WORKSPACE}/admin/webserver/wp_setup.sh" --env-file "${WORKSPACE}/.env" ${_wp_setup_yes_flag}
       exit 0
       ;;
     restore-from-backup)
@@ -306,7 +315,9 @@ first_time_bring_up() {
   info "All containers up. Run './wporchestrator logs' to inspect individual container output."
 
   info "Running WordPress setup ..."
-  bash "${WORKSPACE}/admin/webserver/wp_setup.sh" --env-file "${WORKSPACE}/.env"
+  local _wp_setup_yes_flag=""
+  [ "${yes}" = "true" ] && _wp_setup_yes_flag="--yes"
+  bash "${WORKSPACE}/admin/webserver/wp_setup.sh" --env-file "${WORKSPACE}/.env" ${_wp_setup_yes_flag}
 
   # Create a file to indicate first time bring up is complete and avoid
   # running this function again

--- a/wporchestrator
+++ b/wporchestrator
@@ -313,12 +313,13 @@ first_time_bring_up() {
   [ -e "${WORKSPACE}/src" ] ||
     error "WordPress src bind-mount not found — did the volume fail to populate?"
 
-  # Fix ownership so both the wordpress container (www-data) and the local developer can write.
-  # www-data owns the files; the developer's group gets group-write via setgid + g+w.
-  info "Setting ownership of src/ to www-data:$(id -gn) with group-write ..."
-  sudo chown -R www-data:"$(id -gn)" "${WORKSPACE}/src" || true
-  sudo chmod -R g+w "${WORKSPACE}/src" || true
-  sudo find "${WORKSPACE}/src" -type d -exec chmod g+s {} + || true
+  # Fix permissions on the src/ bind-mount.
+  # Host www-data (uid 33) != container www-data (uid 82 on Alpine fpm), so chown
+  # does not help the container. Instead, make the directory world-writable so any
+  # uid can write (container, host developer, CI root). This is intentional for a
+  # local/preview dev environment — do not use on a hardened production host.
+  info "Setting permissions of src/ to 777 (dev environment) ..."
+  sudo chmod -R 777 "${WORKSPACE}/src" || true
   info "All containers up. Run './wporchestrator logs' to inspect individual container output."
 
   info "Running WordPress setup ..."

--- a/wporchestrator
+++ b/wporchestrator
@@ -313,13 +313,40 @@ first_time_bring_up() {
   [ -e "${WORKSPACE}/src" ] ||
     error "WordPress src bind-mount not found — did the volume fail to populate?"
 
-  # Fix permissions on the src/ bind-mount.
+  # Fix permissions on the src/ bind-mount so the wordpress container can write.
   # Host www-data (uid 33) != container www-data (uid 82 on Alpine fpm), so chown
-  # does not help the container. Instead, make the directory world-writable so any
-  # uid can write (container, host developer, CI root). This is intentional for a
-  # local/preview dev environment — do not use on a hardened production host.
-  info "Setting permissions of src/ to 777 (dev environment) ..."
-  sudo chmod -R 777 "${WORKSPACE}/src" || true
+  # alone does not help. Strategy depends on environment:
+  #
+  #   preview / production (CI, root-owned Droplet):
+  #     chmod 777 — simple, no security concern on an ephemeral/isolated host.
+  #
+  #   local (developer workstation):
+  #     Use POSIX ACLs to grant uid 82 (container www-data) rw access while
+  #     keeping the developer as owner so no sudo is needed for edits.
+  #     Falls back to chown developer:www-data + 775 if setfacl is unavailable.
+  #
+  local _env="${ENVIRONMENT:-local}"
+  if [ "${_env}" = "preview" ] || [ "${_env}" = "production" ]; then
+    info "Preview/production environment — setting src/ to 777 ..."
+    sudo chmod -R 777 "${WORKSPACE}/src" || true
+  else
+    info "Local environment — applying ACL for container uid 82 on src/ ..."
+    if command -v setfacl >/dev/null 2>&1; then
+      # Grant container www-data (uid 82) rwx + propagate to new files via default ACL
+      sudo setfacl -R \
+        -m "u:$(id -un):rwX" \
+        -m "u:82:rwX" \
+        -m "d:u:$(id -un):rwX" \
+        -m "d:u:82:rwX" \
+        "${WORKSPACE}/src" || true
+      info "ACL applied. You can edit src/ without sudo."
+    else
+      warning "setfacl not found — falling back to chown + chmod 775."
+      warning "Install 'acl' package for proper per-uid permissions: sudo apt install acl"
+      sudo chown -R "$(id -un)":"$(id -gn)" "${WORKSPACE}/src" || true
+      sudo chmod -R 775 "${WORKSPACE}/src" || true
+    fi
+  fi
   info "All containers up. Run './wporchestrator logs' to inspect individual container output."
 
   info "Running WordPress setup ..."


### PR DESCRIPTION
feat: add GitHub Actions CI/CD with DigitalOcean deploy and PR previews

Workflows:
- deploy-app.yml: SSH deploy to production Droplet on push to main/develop
  - Bootstrap job creates Droplet if DROPLET_HOST secret is not yet set
- deploy-image.yml: build and push image to DO Container Registry, deploy to Droplet
- deploy-preview.yml: spin up ephemeral pr-{N} Droplet per PR, run full setup, comment live URL
- delete-preview.yml: destroy pr-{N} Droplet when PR is closed
- All workflows: workflow_dispatch trigger with inputs for manual runs
- All workflows: concurrency rules to cancel stale runs and prevent delete/deploy races
- actions/* use floating major version tags; 3rd-party pinned to exact semver

Actions runner compatibility:
- Switch preview Droplet image from docker-20-04 (jammy) to ubuntu-24-04-x64
- Increase SSH session timeout from 10m to 30m for plugin install time
- Skip wp core update in --yes mode to reduce CI runtime
- Poll port 22 before SSH connect to handle Droplet boot lag
- docker compose down before re-deploy to clear stale container name conflicts

File permissions:
- local: setfacl grants container uid 82 rw ACL; developer retains ownership
- preview: chmod 777 (ephemeral host, no concern)
- production: chown 82:82 + chmod 755 (tight, no world-write)
- acl package added to install_basic_packages for local setfacl support

wporchestrator:
- Add --yes / --non-interactive flag forwarded to wp_setup.sh
- Add --force flag to clear .first_time_bring_up_complete sentinel for re-deploy
- Pin WORDPRESS_BLOG_TITLE value in .env heredoc to fix "Preview: command not found"

Fixes:
- tput calls guarded against missing $TERM in CI (no TTY)
- PREVIEW_NAME group key shared between deploy-preview and delete-preview
  so PR close queues behind in-flight deploy instead of racing